### PR TITLE
Configure Gnip streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>pom</packaging>
   <name>twitter4j</name>
   <description>A Java library for the Twitter API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>twitter4j</name>
   <description>A Java library for the Twitter API</description>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-appengine</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-appengine</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-appengine</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-appengine</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-async</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-async</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-async</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-async</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-core</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-core</name>
   <description>A Java library for the Twitter API</description>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-core</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-core</name>
   <description>A Java library for the Twitter API</description>

--- a/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
@@ -109,6 +109,8 @@ public interface Configuration extends AuthorizationConfiguration, java.io.Seria
 
     boolean isDaemonEnabled();
 
+    String getGnipStream();
+
     String getGnipAccount();
 
     String getGnipLabel();

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -42,6 +42,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
     private int httpRetryCount = 0;
     private int httpRetryIntervalSeconds = 5;
 
+    private String gnipStream;
     private String gnipAccount;
     private String gnipLabel;
     private String gnipPublisher = "twitter";
@@ -391,6 +392,14 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
 
     protected final void setHttpRetryIntervalSeconds(int retryIntervalSeconds) {
         this.httpRetryIntervalSeconds = retryIntervalSeconds;
+    }
+
+    public String getGnipStream() {
+        return gnipStream;
+    }
+
+    protected void setGnipStream(String gnipStream) {
+        this.gnipStream = gnipStream;
     }
 
     public String getGnipAccount() {

--- a/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
@@ -47,6 +47,7 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
     private static final String HTTP_RETRY_COUNT = "http.retryCount";
     private static final String HTTP_RETRY_INTERVAL_SECS = "http.retryIntervalSecs";
 
+    private static final String GNIP_STREAM = "gnip.stream";
     private static final String GNIP_ACCOUNT = "gnip.account";
     private static final String GNIP_LABEL = "gnip.label";
     private static final String GNIP_PUBLISHER = "gnip.publisher";
@@ -276,6 +277,9 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
         }
         if (notNull(props, prefix, HTTP_RETRY_INTERVAL_SECS)) {
             setHttpRetryIntervalSeconds(getIntProperty(props, prefix, HTTP_RETRY_INTERVAL_SECS));
+        }
+        if (notNull(props, prefix, GNIP_STREAM)) {
+            setGnipStream(getString(props, prefix, GNIP_STREAM));
         }
         if (notNull(props, prefix, GNIP_ACCOUNT)) {
             setGnipAccount(getString(props, prefix, GNIP_ACCOUNT));

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-examples</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-examples</name>
   <description>A Java library for the Twitter API</description>
@@ -65,22 +65,22 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-async</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-stream</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-media-support</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-examples</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-examples</name>
   <description>A Java library for the Twitter API</description>
@@ -65,22 +65,22 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-async</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-stream</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-media-support</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-media-support</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-media-support</name>
   <description>Twitter4J optional component adds multimedia support
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-media-support</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-media-support</name>
   <description>Twitter4J optional component adds multimedia support
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/twitter4j-spdy-support/pom.xml
+++ b/twitter4j-spdy-support/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-spdy-support</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-spdy-support</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>

--- a/twitter4j-spdy-support/pom.xml
+++ b/twitter4j-spdy-support/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-spdy-support</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-spdy-support</name>
   <description>A Java library for the Twitter API</description>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-stream</artifactId>
-  <version>4.0.6</version>
+  <version>4.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>twitter4j-stream</name>
   <description>A Java library for the Twitter API</description>
@@ -90,12 +90,12 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-async</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.7-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j-stream</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.7</version>
   <packaging>jar</packaging>
   <name>twitter4j-stream</name>
   <description>A Java library for the Twitter API</description>
@@ -90,12 +90,12 @@
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-async</artifactId>
-      <version>4.0.7-SNAPSHOT</version>
+      <version>4.0.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
@@ -66,17 +66,6 @@ public interface TwitterStream extends OAuthSupport, TwitterBase {
      */
     void firehose(final int count);
     
-    /**
-     * Starts listening on all public statuses and includes geolocation information as value of user/filters/placeid. Available only to approved parties and requires a signed agreement to access. Please do not contact us about access to the firehose. If your service warrants access to it, we'll contact you.
-     *
-     * @param count Indicates the number of previous statuses to stream before transitioning to the live stream.
-     * @param partitions Lists partition numbers separated by comma as a string e.g. "0,1,2,3"
-     * @see twitter4j.StatusStream
-     * @see <a href="https://dev.twitter.com/docs/streaming-api/methods">Streaming API Methods statuses/firehose</a>
-     * @since Twitter4J 2.0.4
-     */
-    void geohose(final int count, final String partitions);
-
     void gnipFirehose(final int partition);
 
     /**

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
@@ -65,8 +65,10 @@ public interface TwitterStream extends OAuthSupport, TwitterBase {
      * @since Twitter4J 2.0.4
      */
     void firehose(final int count);
-    
-    void gnipFirehose(final int partition);
+
+    void gnipStream();
+
+    void gnipPartitionedStream(final int partition);
 
     /**
      * Starts listening on all public statuses containing links. Available only to approved parties and requires a signed agreement to access. Please do not contact us about access to the links stream. If your service warrants access to it, we'll contact you.

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -95,30 +95,6 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
         });
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void geohose(final int count, final String partitions) {
-        ensureAuthorizationEnabled();
-        ensureStatusStreamListenerIsSet();
-        startHandler(new TwitterStreamConsumer(Mode.status) {
-            @Override
-            public StatusStream getStream() throws TwitterException {
-                ensureAuthorizationEnabled();
-                final List<HttpParameter> params = new ArrayList<HttpParameter>();
-
-                params.add(new HttpParameter("include_fields", "public_location"));
-                params.add(new HttpParameter("count", String.valueOf(count)));
-
-                if (null != partitions) {
-                    params.add(new HttpParameter("partitions", partitions));
-                }
-                return getPostCountStream("statuses/firehose.json", params.toArray(new HttpParameter[params.size()]));
-            }
-        });
-    }
-
     StatusStream getFirehoseStream(int count) throws TwitterException {
         ensureAuthorizationEnabled();
         return getPostCountStream("statuses/firehose.json", count);

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -83,11 +83,12 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
 
                 params.add(new HttpParameter("partition", Integer.toString(partition)));
 
+                String stream    = conf.getGnipStream();
                 String account   = conf.getGnipAccount();
                 String publisher = conf.getGnipPublisher();
                 String label     = conf.getGnipLabel();
 
-                String path = String.format("stream/firehose/accounts/%s/publishers/%s/%s.json", account, publisher, label);
+                String path = String.format("stream/%s/accounts/%s/publishers/%s/%s.json", stream, account, publisher, label);
 
                 return getCountStream(path, params.toArray(new HttpParameter[params.size()]));
             }


### PR DESCRIPTION
For realtime tracking we're going to use PowerTrack and for DHTS we're going to use decahose connection.

In order to track realtime and DHTS with PowerTrack API we'll need to be able to configure gnip stream name, previously it was hardcoded to "firehose".

Other than that because PowerTrack doesn't support partitions and Decahose do we need to have ability to choose whether we want to use partitions or not.